### PR TITLE
Enabled cors

### DIFF
--- a/template/node10-express-arm64/index.js
+++ b/template/node10-express-arm64/index.js
@@ -7,7 +7,7 @@ const express = require('express')
 const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
-
+const cors = require("cors");// imported cors package
 // app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(bodyParser.raw());
@@ -80,10 +80,15 @@ var middleware = (req, res) => {
     handler(fnEvent, fnContext, cb);
 };
 
+app.use(cors());//  enabled cors
 app.post('/*', middleware);
+app.use(cors());//  enabled cors
 app.get('/*', middleware);
+app.use(cors());//  enabled cors
 app.patch('/*', middleware);
+app.use(cors());//  enabled cors
 app.put('/*', middleware);
+app.use(cors());//  enabled cors
 app.delete('/*', middleware);
 
 const port = process.env.http_port || 3000;

--- a/template/node10-express-arm64/package.json
+++ b/template/node10-express-arm64/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.18.2",
+     "cors": "^2.8.5",
     "express": "^4.16.2"
   }
 }

--- a/template/node10-express-armhf/index.js
+++ b/template/node10-express-armhf/index.js
@@ -7,7 +7,7 @@ const express = require('express')
 const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
-
+const cors = require("cors");// imported cors package
 // app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(bodyParser.raw());
@@ -80,10 +80,15 @@ var middleware = (req, res) => {
     handler(fnEvent, fnContext, cb);
 };
 
+app.use(cors());//  enabled cors
 app.post('/*', middleware);
+app.use(cors());//  enabled cors
 app.get('/*', middleware);
+app.use(cors());//  enabled cors
 app.patch('/*', middleware);
+app.use(cors());//  enabled cors
 app.put('/*', middleware);
+app.use(cors());//  enabled cors
 app.delete('/*', middleware);
 
 const port = process.env.http_port || 3000;

--- a/template/node10-express-armhf/package.json
+++ b/template/node10-express-armhf/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.18.2",
+     "cors": "^2.8.5",
     "express": "^4.16.2"
   }
 }

--- a/template/node10-express/index.js
+++ b/template/node10-express/index.js
@@ -7,7 +7,7 @@ const express = require('express')
 const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
-
+const cors = require("cors");// imported cors package
 // app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(bodyParser.raw());
@@ -21,7 +21,6 @@ class FunctionEvent {
         this.method = req.method;
         this.query = req.query;
         this.path = req.path;
-        
     }
 }
 
@@ -81,10 +80,15 @@ var middleware = (req, res) => {
     handler(fnEvent, fnContext, cb);
 };
 
+app.use(cors());//  enabled cors
 app.post('/*', middleware);
+app.use(cors());//  enabled cors
 app.get('/*', middleware);
+app.use(cors());//  enabled cors
 app.patch('/*', middleware);
+app.use(cors());//  enabled cors
 app.put('/*', middleware);
+app.use(cors());//  enabled cors
 app.delete('/*', middleware);
 
 const port = process.env.http_port || 3000;

--- a/template/node10-express/index.js
+++ b/template/node10-express/index.js
@@ -21,6 +21,7 @@ class FunctionEvent {
         this.method = req.method;
         this.query = req.query;
         this.path = req.path;
+        this.params=req.params
     }
 }
 

--- a/template/node10-express/index.js
+++ b/template/node10-express/index.js
@@ -21,7 +21,7 @@ class FunctionEvent {
         this.method = req.method;
         this.query = req.query;
         this.path = req.path;
-        this.params=req.params;
+        
     }
 }
 

--- a/template/node10-express/index.js
+++ b/template/node10-express/index.js
@@ -21,7 +21,7 @@ class FunctionEvent {
         this.method = req.method;
         this.query = req.query;
         this.path = req.path;
-        this.params=req.params
+        this.params=req.params;
     }
 }
 

--- a/template/node10-express/package.json
+++ b/template/node10-express/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.18.2",
+     "cors": "^2.8.5",
     "express": "^4.16.2"
   }
 }


### PR DESCRIPTION
Hi, 
I was creating a short URL service with openfaas , while integrating the function with react js front end, It showed 

> Access to fetch at 'http://192.168.99.100:31112/function/getstat' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled

. so I edited the templates which enable cors and it worked fine, so I thought it would be a good feature to add to the templates