### PR TITLE
Add env var to use raw body and set max json size

### DIFF
--- a/template/node10-express-arm64/index.js
+++ b/template/node10-express-arm64/index.js
@@ -8,10 +8,15 @@ const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
 
-// app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(bodyParser.raw());
-app.use(bodyParser.text({ type : "text/*" }));
+if (process.env.RAW_BODY === 'true') {
+    app.use(bodyParser.raw({ type: '*/*' }))
+} else {
+    var jsonLimit = process.env.MAX_JSON_SIZE || '100kb' //body-parser default
+    app.use(bodyParser.json({ limit: jsonLimit}));
+    app.use(bodyParser.raw()); // "Content-Type: application/octet-stream"
+    app.use(bodyParser.text({ type : "text/*" }));
+}
+
 app.disable('x-powered-by');
 
 class FunctionEvent {

--- a/template/node10-express-armhf/index.js
+++ b/template/node10-express-armhf/index.js
@@ -8,10 +8,15 @@ const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
 
-// app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(bodyParser.raw());
-app.use(bodyParser.text({ type : "text/*" }));
+if (process.env.RAW_BODY === 'true') {
+    app.use(bodyParser.raw({ type: '*/*' }))
+} else {
+    var jsonLimit = process.env.MAX_JSON_SIZE || '100kb' //body-parser default
+    app.use(bodyParser.json({ limit: jsonLimit}));
+    app.use(bodyParser.raw()); // "Content-Type: application/octet-stream"
+    app.use(bodyParser.text({ type : "text/*" }));
+}
+
 app.disable('x-powered-by');
 
 class FunctionEvent {

--- a/template/node10-express/index.js
+++ b/template/node10-express/index.js
@@ -8,10 +8,15 @@ const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
 
-// app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(bodyParser.raw());
-app.use(bodyParser.text({ type : "text/*" }));
+if (process.env.RAW_BODY === 'true') {
+    app.use(bodyParser.raw({ type: '*/*' }))
+} else {
+    var jsonLimit = process.env.MAX_JSON_SIZE || '100kb' //body-parser default
+    app.use(bodyParser.json({ limit: jsonLimit}));
+    app.use(bodyParser.raw()); // "Content-Type: application/octet-stream"
+    app.use(bodyParser.text({ type : "text/*" }));
+}
+
 app.disable('x-powered-by');
 
 class FunctionEvent {


### PR DESCRIPTION
This change adds the use of 2 environment variables allowing users to receive the
request body as a buffer (the 'raw' body) as well as the ability to set the maximum
JSON body size.

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

For more information and testing results, see the main node12 PR: https://github.com/openfaas/templates/pull/195