### PR TITLE
Include the node10-express-service template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The template makes use of the OpenFaaS incubator project [of-watchdog](https://g
 
 ## Supported platforms
 
-* x86_64 - `node10-express`
+* x86_64 - `node10-express` and `node10-express-service`
 * armhf - `node10-express-armhf`
 
 ## Trying the template
@@ -21,7 +21,7 @@ $ faas template pull https://github.com/openfaas-incubator/node10-express-templa
 $ faas new --lang node10-express
 ```
 
-## Example usage
+## Example usage - node10-express, node10-express-arm64, node10-express-armhf
 
 ### Success and JSON body
 
@@ -121,3 +121,87 @@ Other reference:
 * `.status(code)` - overrides the status code used by `fail`, or `succeed`
 * `.fail(object)` - returns a 500 error if `.status(code)` was not called prior to that
 * `.succeed(object)` - returns a 200 code if `.status(code)` was not called prior to that
+
+## Example usage - node10-express-service
+This template provides Node.js 10 (LTS) and full access to [express.js](http://expressjs.com/en/api.html#req.is) for building microservices for [OpenFaaS](https://www.openfaas.com), Docker, Knative and Cloud Run.
+
+With this template you can create a new microservice and deploy it to a platform like [OpenFaaS](https://www.openfaas.com) for:
+
+* scale-to-zero
+* horizontal scale-out
+* metrics & logs
+* automated health-checks
+* sane Kubernetes defaults like running as a non-root user
+
+### Minimal example with one route
+
+```js
+"use strict"
+
+module.exports = async (config) => {
+    const app = config.app;
+
+    app.get('/', (req, res) => {
+        res.send("Hello world");
+    });
+}
+```
+
+### Minimal example with one route and `npm` package
+
+```
+npm install --save moment
+```
+
+```js
+"use strict"
+
+const moment = require('moment');
+
+module.exports = async (config) => {
+    const app = config.app;
+
+    app.get('/', (req, res) => {
+        res.send(moment());
+    });
+}
+```
+
+### Example usage with multiple routes, middleware and ES6
+
+```js
+"use strict"
+
+module.exports = async (config) => {
+    const routing = new Routing(config.app);
+    routing.configure();
+    routing.bind(routing.handle);
+}
+
+class Routing {
+    constructor(app) {
+        this.app = app;
+    }
+
+    configure() {
+        const bodyParser = require('body-parser')
+        this.app.use(bodyParser.json());
+        this.app.use(bodyParser.raw());
+        this.app.use(bodyParser.text({ type : "text/*" }));
+    }
+
+    bind(route) {
+        this.app.post('/*', route);
+        this.app.get('/*', route);
+        this.app.patch('/*', route);
+        this.app.put('/*', route);
+        this.app.delete('/*', route);
+    }
+
+    handle(req, res) {
+        res.send(JSON.stringify(req.body));
+    }
+}
+```
+
+*handler.js*

--- a/template/node10-express-service/Dockerfile
+++ b/template/node10-express-service/Dockerfile
@@ -1,0 +1,59 @@
+FROM openfaas/of-watchdog:0.5.3 as watchdog
+
+FROM node:10.12.0-alpine as ship
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+RUN addgroup -S app && adduser -S -g app app
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Turn down the verbosity to default level.
+ENV NPM_CONFIG_LOGLEVEL warn
+
+RUN mkdir -p /home/app
+
+# Wrapper/boot-strapper
+WORKDIR /home/app
+COPY package.json ./
+
+# This ordering means the npm installation is cached for the outer function handler.
+RUN npm i
+
+# Copy outer function handler
+COPY index.js ./
+
+# COPY function node packages and install, adding this as a separate
+# entry allows caching of npm install
+WORKDIR /home/app/function
+COPY function/*.json ./
+RUN npm i || :
+
+# COPY function files and folders
+COPY function/ ./
+
+# Set correct permissions to use non root user
+WORKDIR /home/app/
+
+# chmod for tmp is for a buildkit issue (@alexellis)
+RUN chown app:app -R /home/app \
+    && chmod 777 /tmp
+
+USER app
+
+ENV cgi_headers="true"
+ENV fprocess="node index.js"
+ENV mode="http"
+ENV upstream_url="http://127.0.0.1:3000"
+
+ENV exec_timeout="10s"
+ENV write_timeout="15s"
+ENV read_timeout="15s"
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]
+

--- a/template/node10-express-service/function/handler.js
+++ b/template/node10-express-service/function/handler.js
@@ -1,0 +1,33 @@
+"use strict"
+
+module.exports = async (config) => {
+    const routing = new Routing(config.app);
+    routing.configure();
+    routing.bind(routing.handle);
+}
+
+class Routing {
+    constructor(app) {
+        this.app = app;
+    }
+
+    configure() {
+        const bodyParser = require('body-parser')
+        this.app.use(bodyParser.json());
+        this.app.use(bodyParser.raw());
+        this.app.use(bodyParser.text({ type : "text/*" }));
+        this.app.disable('x-powered-by');        
+    }
+
+    bind(route) {
+        this.app.post('/*', route);
+        this.app.get('/*', route);
+        this.app.patch('/*', route);
+        this.app.put('/*', route);
+        this.app.delete('/*', route);
+    }
+
+    handle(req, res) {
+        res.send(JSON.stringify(req.body));
+    }
+}

--- a/template/node10-express-service/function/package.json
+++ b/template/node10-express-service/function/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "function",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/template/node10-express-service/index.js
+++ b/template/node10-express-service/index.js
@@ -1,0 +1,21 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"use strict"
+
+const express = require('express')
+const app = express()
+const handler = require('./function/handler');
+
+async function init() {
+    await handler({"app": app});
+
+    const port = process.env.http_port || 3000;
+    app.disable('x-powered-by');
+
+    app.listen(port, () => {
+        console.log(`node10-express-service, listening on port: ${port}`)
+    });    
+}
+
+init();

--- a/template/node10-express-service/package.json
+++ b/template/node10-express-service/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node10-express",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.18.2",
+    "express": "^4.16.2"
+  }
+}

--- a/template/node10-express-service/template.yml
+++ b/template/node10-express-service/template.yml
@@ -1,0 +1,2 @@
+language: node10-express-service
+fprocess: node index.js


### PR DESCRIPTION
Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

Bringing in the other node10-express template to be included with the other express templates.

This is a cut and copy from the [node10-express-service](https://github.com/openfaas-incubator/node10-express-service/) repo. I've also updated the readme to include examples and segregation with the new template.

This will resolve the issue in the original repository: https://github.com/openfaas-incubator/node10-express-service/issues/2

Unfortunately, I'm unable to `faas pull` this from a branch other than master, but I was able to test it by copying the files and running `faas new --list`

```sh
$ faas new --list
Languages available as templates:
- node10-express
- node10-express-arm64
- node10-express-armhf
- node10-express-service
```

and created a new function with the newly added template:

```sh
$ faas new check --lang node10-express-service
Folder: check created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: check
Stack file written: check.yml
```